### PR TITLE
Fix import path in api/server.js

### DIFF
--- a/api/server.js
+++ b/api/server.js
@@ -1,6 +1,6 @@
 // server.js
 import express from 'express';
-import evaluateHandler from './api/evaluate.js';
+import evaluateHandler from './evaluate.js';
 
 const app = express();
 const port = 3000;


### PR DESCRIPTION
## Summary
- fix evaluate handler path

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6858eda35da083288de074b115a82dc2