### PR TITLE
docs: add basic usage to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,14 @@
 # selleasy-offer-engine
 API to evaluate real estate offers based on location, condition and property size
+
+## Usage
+
+1. Install dependencies:
+   ```bash
+   npm install
+   ```
+2. Start the development server:
+   ```bash
+   npm run dev
+   ```
+   The API will start on [http://localhost:3000](http://localhost:3000).


### PR DESCRIPTION
## Summary
- document how to install dependencies and run the dev API server in README

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6858ef4f35148328beddcad3372ee690