### PR TITLE
Add Jest and fallback price tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "API to evaluate real estate offers based on location, condition and property size",
   "main": "index.js",
   "scripts": {
-    "dev": "node --watch server.js"
+    "dev": "node --watch server.js",
+    "test": "node --experimental-vm-modules node_modules/jest/bin/jest.js"
   },
   "repository": {
     "type": "git",
@@ -21,5 +22,8 @@
     "express": "^5.1.0",
     "node-fetch": "^2.7.0",
     "puppeteer": "^24.10.2"
+  },
+  "devDependencies": {
+    "jest": "^29.7.0"
   }
 }

--- a/utils/__tests__/externalPriceSearch.test.js
+++ b/utils/__tests__/externalPriceSearch.test.js
@@ -1,0 +1,12 @@
+import { getFallbackPricePerSqm } from '../externalPriceSearch.js';
+
+describe('getFallbackPricePerSqm', () => {
+  test('known city and neighborhood returns specific price', () => {
+    expect(getFallbackPricePerSqm('תל אביב', 'נוה צדק')).toBe(47000);
+  });
+
+  test('unknown city falls back to 25000', () => {
+    expect(getFallbackPricePerSqm('Unknown City')).toBe(25000);
+  });
+});
+

--- a/utils/externalPriceSearch.js
+++ b/utils/externalPriceSearch.js
@@ -27,4 +27,3 @@ export function getFallbackPricePerSqm(city, neighborhood = "") {
   
     return cityData[neighborhood] || cityData["default"] || 25000;
   }
-  


### PR DESCRIPTION
## Summary
- fix stray newline in `externalPriceSearch.js`
- add Jest as dev dependency
- provide `npm test` script
- cover fallback pricing logic with Jest tests

## Testing
- `npm test` *(fails: Cannot find module 'jest' because dependencies are not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6858ef5a691483289efefe4cfff11336