### PR TITLE
fix: clean extraneous text from externalPriceSearch

### DIFF
--- a/utils/externalPriceSearch.js
+++ b/utils/externalPriceSearch.js
@@ -27,4 +27,3 @@ export function getFallbackPricePerSqm(city, neighborhood = "") {
   
     return cityData[neighborhood] || cityData["default"] || 25000;
   }
-  


### PR DESCRIPTION
## Summary
- remove stray shell prompt from `externalPriceSearch.js`

## Testing
- `npm run lint` *(fails: Missing script "lint")*

------
https://chatgpt.com/codex/tasks/task_e_6858ef333a708328b1d43b695b100d5d